### PR TITLE
specify lombok version

### DIFF
--- a/corona-tracker-backend/pom.xml
+++ b/corona-tracker-backend/pom.xml
@@ -31,6 +31,7 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
+			<version>1.18.28</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>


### PR DESCRIPTION
earlier lombok versions threw this error:
```
java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment
```